### PR TITLE
Minor updates in docs

### DIFF
--- a/lib/occi/cli/occi_opts.rb
+++ b/lib/occi/cli/occi_opts.rb
@@ -176,7 +176,7 @@ module Occi::Cli
         opts.on("-j",
                 "--link URI",
                 Array,
-                "URI of an instance to be linked with the given resource, applicable for actions 'create' and 'link'") do |links|
+                "URI of an instance to be linked with the given resource, applicable only for action 'link'") do |links|
           options.links ||= []
 
           links.each do |link|

--- a/lib/occi/cli/occi_opts/cli_examples.erb
+++ b/lib/occi/cli/occi_opts/cli_examples.erb
@@ -22,9 +22,6 @@ occi --endpoint <%= ENDPOINT -%> --action describe --resource <%= res -%>
 ## Creating resources
 <% %w(compute network storage).each do |res| %>
 occi --endpoint <%= ENDPOINT -%> --action create [ --attribute attribute_name='attribute_value' ]+ [ --mixin mixin_type#mixin_term ]+ --resource <%= res -%>
-<% if res == 'compute' %>
-occi --endpoint <%= ENDPOINT -%> --action create [ --attribute attribute_name='attribute_value' ]+ [ --link /resource_type/instance_id ]+ --resource <%= res -%>
-<% end -%>
 <% end %>
 
 ## Linking/unlinking resources


### PR DESCRIPTION
Updated old docs and invalid examples showing linking with the
`create` action. This is no longer supported.
