### PR TITLE
Option to allow insecure SSL connections (without strict validation)

### DIFF
--- a/lib/occi/cli/occi_opts.rb
+++ b/lib/occi/cli/occi_opts.rb
@@ -89,6 +89,12 @@ module Occi::Cli
           options.auth.ca_file = ca_file
         end
 
+        opts.on("-s",
+                "--skip-ca-check",
+                "Skip server certificate verification [NOT recommended]") do
+          silence_warnings { OpenSSL::SSL.const_set(:VERIFY_PEER, OpenSSL::SSL::VERIFY_NONE) }
+        end
+
         opts.on("-F",
                 "--filter CATEGORY",
                 String,


### PR DESCRIPTION
Added the `--skip-ca-check` option for skipping server certificate validation on SSL connections.
